### PR TITLE
Add S3 presigned URL support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.842.0",
+    "@aws-sdk/s3-request-presigner": "^3.842.0",
     "@aws-sdk/client-textract": "^3.840.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",

--- a/src/files/files.service.spec.ts
+++ b/src/files/files.service.spec.ts
@@ -15,4 +15,13 @@ describe('FilesService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  it('should generate a presigned url', async () => {
+    process.env.AWS_ACCESS_BUCKET = 'bucket';
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.AWS_ACCESS_KEY_ID = 'key';
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret';
+    const url = await service.generatePresignedUrl('folder', 'file', 60);
+    expect(typeof url).toBe('string');
+  });
 });

--- a/src/files/files.service.ts
+++ b/src/files/files.service.ts
@@ -7,6 +7,7 @@ import {
   PutObjectCommand,
   GetObjectCommand,
 } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Readable } from 'stream';
 
 // DTO
@@ -87,5 +88,16 @@ export class FilesService {
       this.logger.error('Failed to download file', err);
       throw err;
     }
+  }
+
+  async generatePresignedUrl(
+    folder: string,
+    key: string,
+    expiresIn = 3600,
+  ): Promise<string> {
+    const bucket = process.env.AWS_ACCESS_BUCKET ?? 'bucket';
+    const s3Key = `${folder}/${key}`;
+    const command = new GetObjectCommand({ Bucket: bucket, Key: s3Key });
+    return getSignedUrl(this.s3, command, { expiresIn });
   }
 }

--- a/src/open-ai/open-ai.service.ts
+++ b/src/open-ai/open-ai.service.ts
@@ -118,9 +118,14 @@ export class OpenAiService implements OnModuleInit, OnModuleDestroy {
       throw new Error('File not found');
     }
 
+    const presigned = await this.filesService.generatePresignedUrl(
+      file.folder,
+      file.file,
+    );
+
     return {
       content: ocr.content,
-      image: file.url,
+      image: presigned,
       extension: file.extension,
     };
   }


### PR DESCRIPTION
## Summary
- add `@aws-sdk/s3-request-presigner` dependency
- support presigned URL generation in `FilesService`
- use presigned URLs when sending images to OpenAI
- test `generatePresignedUrl` helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867812aeed0832598591939fc2f3785