### PR TITLE
Fix AI thread waiting logic

### DIFF
--- a/src/open-ai/open-ai.service.ts
+++ b/src/open-ai/open-ai.service.ts
@@ -186,7 +186,8 @@ ${text}`.trim();
 
     while (
       runStatus.status === 'queued' ||
-      runStatus.status === 'in_progress'
+      runStatus.status === 'in_progress' ||
+      runStatus.status === 'requires_action'
     ) {
       await new Promise((resolve) => setTimeout(resolve, 2000));
       runStatus = await this.openai.beta.threads.runs.retrieve(threadId, runId);


### PR DESCRIPTION
## Summary
- ensure OpenAI run waits for completion

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678dd3ed988325b67afcc6b3505b90