### PR TITLE
Implement product categories and rename AI details

### DIFF
--- a/src/ocr/ocr.service.ts
+++ b/src/ocr/ocr.service.ts
@@ -17,6 +17,7 @@ import { TaxCouponStatus } from '@prisma/client';
 interface ProcessJobData {
   taxCouponId: string;
   fileId: string;
+  categories?: string[];
 }
 
 @Injectable()
@@ -53,7 +54,8 @@ export class OcrService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async process(job: Job<ProcessJobData>) {
-    const { taxCouponId, fileId } = job.data;
+    const { taxCouponId, fileId, categories } = job.data;
+    this.logger.verbose(`Starting OCR processing for taxCoupon ${taxCouponId}`);
     try {
       await this.prisma.taxCoupon.update({
         where: { id: taxCouponId },
@@ -97,6 +99,7 @@ export class OcrService implements OnModuleInit, OnModuleDestroy {
       await this.aiQueue.add('process-ai', {
         taxCouponId,
         fileId,
+        categories,
       });
     } catch (error) {
       this.logger.error('OCR processing failed', error as Error);

--- a/src/tax-coupon/dto/create-tax-coupon.dto.ts
+++ b/src/tax-coupon/dto/create-tax-coupon.dto.ts
@@ -1,5 +1,6 @@
 // Dependencies
 import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsString } from 'class-validator';
 
 export class CreateTaxCouponDto {
   @ApiProperty({
@@ -8,4 +9,13 @@ export class CreateTaxCouponDto {
     format: 'binary',
   })
   file!: Express.Multer.File;
+
+  @ApiProperty({
+    description: 'Categorias de produtos',
+    type: [String],
+    required: false,
+  })
+  @IsArray()
+  @IsString({ each: true })
+  categories?: string[];
 }

--- a/src/tax-coupon/dto/tax-coupon-details.dto.ts
+++ b/src/tax-coupon/dto/tax-coupon-details.dto.ts
@@ -141,5 +141,5 @@ export class TaxCouponAiDto {
 
 export class TaxCouponDetailsDto extends TaxCouponResponseDto {
   @ApiProperty({ type: () => TaxCouponAiDto, required: false })
-  ai?: TaxCouponAiDto | null;
+  details?: TaxCouponAiDto | null;
 }

--- a/src/tax-coupon/tax-coupon.controller.ts
+++ b/src/tax-coupon/tax-coupon.controller.ts
@@ -4,6 +4,7 @@ import {
   Post,
   UseInterceptors,
   UploadedFile,
+  Body,
   Logger,
   Get,
   Param,
@@ -37,9 +38,12 @@ export class TaxCouponController {
   @ApiBody({ type: CreateTaxCouponDto })
   @ApiCreatedResponse({ type: TaxCouponResponseDto })
   @UseInterceptors(FileInterceptor('file'))
-  async create(@UploadedFile() file: Express.Multer.File) {
+  async create(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() body: CreateTaxCouponDto,
+  ) {
     try {
-      return this.taxCouponService.create(file);
+      return this.taxCouponService.create(file, body.categories);
     } catch (error) {
       this.logger.error('Failed to create tax coupon', error as Error);
       throw error;


### PR DESCRIPTION
## Summary
- let TaxCoupon creation accept categories
- pass categories through OCR and AI queue flow
- log verbosely when starting OCR and AI processes
- rename DTO output from `ai` to `details`
- add categories to CreateTaxCouponDto

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679a6456808325a821112a07efa193