### PR TITLE
Fix Swagger metadata generation by disabling minification

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -28,7 +28,8 @@ plugins:
 custom:
   esbuild:
     bundle: true
-    minify: true
+    # Minification breaks Swagger metadata generation; disable to preserve class names
+    minify: false
     target: node20
     platform: node
     concurrency: 10


### PR DESCRIPTION
## Summary
- disable esbuild minification in `serverless.yml`

Disabling minification prevents class name mangling which caused a circular dependency error in Swagger when running on AWS Lambda.

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686807a79c748325a244666aa8c1fd1c