### PR TITLE
Fix swagger type metadata for lambda

### DIFF
--- a/src/tax-coupon/dto/tax-coupon-details.dto.ts
+++ b/src/tax-coupon/dto/tax-coupon-details.dto.ts
@@ -135,7 +135,7 @@ export class TaxCouponAiDto {
   @ApiProperty({ type: () => TaxCouponAiCustomerDto, required: false })
   customer?: TaxCouponAiCustomerDto | null;
 
-  @ApiProperty()
+  @ApiProperty({ type: Date })
   createdAt!: Date;
 }
 

--- a/src/tax-coupon/dto/tax-coupon-response.dto.ts
+++ b/src/tax-coupon/dto/tax-coupon-response.dto.ts
@@ -8,12 +8,12 @@ export class TaxCouponResponseDto {
   @ApiProperty({ enum: TaxCouponStatus })
   status!: TaxCouponStatus;
 
-  @ApiProperty()
+  @ApiProperty({ type: String })
   fileId!: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: Date })
   createdAt!: Date;
 
-  @ApiProperty()
+  @ApiProperty({ type: Date })
   updatedAt?: Date;
 }


### PR DESCRIPTION
## Summary
- define explicit `@ApiProperty()` types for file ID and date fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680c0b3b388325b81e767c30847216