### PR TITLE
Fix swagger blank page in lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -35,6 +35,7 @@ custom:
       - '@nestjs/microservices'
       - '@nestjs/microservices/microservices-module'
       - '@nestjs/websockets/socket-module'
+      - swagger-ui-dist
 
 plugins:
   - serverless-esbuild


### PR DESCRIPTION
## Summary
- ensure swagger UI files are available in AWS Lambda by packaging `swagger-ui-dist`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681233c81c8325a075e5dc380c3307