### PR TITLE
Remove datadog wrapper

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,11 +1,11 @@
 // Dependencies
+import 'reflect-metadata';
 import helmet from 'helmet';
 import express from 'express';
 import { NestFactory } from '@nestjs/core';
 import { ExpressAdapter } from '@nestjs/platform-express';
 import { ValidationPipe } from '@nestjs/common';
 import { Handler } from 'aws-lambda';
-import { datadog } from 'datadog-lambda-js';
 
 // Dependencies
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
@@ -39,15 +39,14 @@ async function bootstrap(): Promise<Handler> {
 
     await app.init();
 
-    const { handler } = serverlessExpress({ app: expressApp });
-    cachedHandler = handler;
+    cachedHandler = serverlessExpress({ app: expressApp });
   }
   return cachedHandler;
 }
 
-export const handler: Handler = datadog(async (event, context, callback) => {
+export const handler: Handler = async (event, context, callback) => {
   context.callbackWaitsForEmptyEventLoop = false;
   const handlerFunc = await bootstrap();
   return handlerFunc(event, context, callback);
-});
+};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 // Dependencies
+import 'reflect-metadata';
 import helmet from 'helmet';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';


### PR DESCRIPTION
## Summary
- drop datadog instrumentation from the lambda entry point

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686821127f048325bee5adfe9e543a1c